### PR TITLE
Remove import scipy.fftpack._fftpack and functions

### DIFF
--- a/ghost/sigtools/fourier.py
+++ b/ghost/sigtools/fourier.py
@@ -2,26 +2,27 @@
 
 import logging
 import numpy as np
-import scipy.fftpack._fftpack as sff
+# import scipy.fftpack._fftpack as sff # gone from more recent versions of scipy()
 from . import convolution
 
 __all__ = ['clean_scipy_cache', 'chirpz_dft']
 
 def clean_scipy_cache():
-    sff.destroy_zfft_cache()
-    sff.destroy_zfftnd_cache()
-    sff.destroy_drfft_cache()
-    sff.destroy_cfft_cache()
-    sff.destroy_cfftnd_cache()
-    sff.destroy_rfft_cache()
-    sff.destroy_ddct2_cache()
-    sff.destroy_ddct1_cache()
-    sff.destroy_dct2_cache()
-    sff.destroy_dct1_cache()
-    sff.destroy_ddst2_cache()
-    sff.destroy_ddst1_cache()
-    sff.destroy_dst2_cache()
-    sff.destroy_dst1_cache()
+    pass
+    # sff.destroy_zfft_cache()
+    # sff.destroy_zfftnd_cache()
+    # sff.destroy_drfft_cache()
+    # sff.destroy_cfft_cache()
+    # sff.destroy_cfftnd_cache()
+    # sff.destroy_rfft_cache()
+    # sff.destroy_ddct2_cache()
+    # sff.destroy_ddct1_cache()
+    # sff.destroy_dct2_cache()
+    # sff.destroy_dct1_cache()
+    # sff.destroy_ddst2_cache()
+    # sff.destroy_ddst1_cache()
+    # sff.destroy_dst2_cache()
+    # sff.destroy_dst1_cache()
 
 def chirpz_dft(x):
     """Computes the DFT of a signal using the Chirp Z-transform.


### PR DESCRIPTION
This now removes the ability to clear the scipy fft cache. Is there another way?